### PR TITLE
DM on no message perms

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,6 +45,19 @@ async def on_ready():
     print(bot.user.name)
     print('Signed into bot user.')
 
+@bot.event
+async def on_message(ctx):
+    context = await bot.get_context(ctx)
+        if context.valid:
+            if isinstance(ctx.channel, discord.TextChannel):
+                if not ctx.channel.permissions_for(ctx.channel.guild.me).send_messages:
+                    try:
+                        await ctx.author.send(f"*Houston, we have a problem!*\nYou tried to use `{ctx.content}` in {ctx.channel.mention}, but I don't have message permissions there.\nGive me perms and try again!")
+                    except discord.Forbidden:
+                        pass # DMs disabled!
+                else:
+                    await bot.process_commands(ctx)
+
   # All of the following commands are currently MANDATORY, these commands are part of the MAIN system other commands are added using a seperate file.
 
 


### PR DESCRIPTION
Kanelbulle should DM people when they don't have message perms in a channel where a command was run.

This will avoid commands being half-done because of errors when trying to send messages!