### PR TITLE
New moderation stuff

### DIFF
--- a/cogs/moderating.py
+++ b/cogs/moderating.py
@@ -15,11 +15,36 @@ class ModCog:
 
     @commands.has_permissions(ban_members=True)
     @commands.command(name='ban')
-    async def banusr(self, ctx, member: discord.Member, reason: str):
-        await ctx.message.guild.ban(member)
-        await ctx.send("User has been banned. oof.")
+    async def banusr(self, ctx, member, reason: str = "No reason provided"):
+        try:
+            toban = await commands.MemberConverter().convert(ctx, argument=member)
+        except:
+            try:
+                toban = await commands.UserConverter().convert(ctx, argument=member)
+            except:
+                raise commands.BadArgument(message=ctx)
+        await ctx.message.guild.ban(toban, delete_message_days = 7, reason = f"{ctx.author} - {reason}")
+        await ctx.send(f":eyes: {str(toban)} has been banned. oof.")
 
+    @commands.has_permissions(ban_members=True)
+    @commands.command(name='softban')
+    async def softbanusr(self, ctx, member, reason: str = "No reason provided"):
+        try:
+            toban = await commands.MemberConverter().convert(ctx, argument=member)
+        except:
+            try:
+                toban = await commands.UserConverter().convert(ctx, argument=member)
+            except:
+                raise commands.BadArgument(message=ctx)
+        await ctx.message.guild.ban(toban, delete_message_days = 7, reason = f"{ctx.author} (Softban) - {reason}")
+        await ctx.message.guild.unban(toban, reason = f"{ctx.author} (Softban) - {reason}")
+        await ctx.send(f":eyes: {str(toban)} has been soft banned.\nThis means they have been kicked, with messages less than 7 days old deleted.")
 
+    @commands.has_permissions(kick_members=True)
+    @commands.command(name='kick')
+    async def kickusr(self, ctx, member: discord.Member, reason: str = "No reason provided"):
+        await ctx.message.guild.kick(member, reason=f"{ctx.author} (Softban) - {reason}")
+        await ctx.send(f":eyes: {str(member)} has been kicked. oof.")
 
 
 # Add moderating cog to main instance.

--- a/main.py
+++ b/main.py
@@ -48,15 +48,15 @@ async def on_ready():
 @bot.event
 async def on_message(ctx):
     context = await bot.get_context(ctx)
-        if context.valid:
-            if isinstance(ctx.channel, discord.TextChannel):
-                if not ctx.channel.permissions_for(ctx.channel.guild.me).send_messages:
-                    try:
-                        await ctx.author.send(f"*Houston, we have a problem!*\nYou tried to use `{ctx.content}` in {ctx.channel.mention}, but I don't have message permissions there.\nGive me perms and try again!")
-                    except discord.Forbidden:
-                        pass # DMs disabled!
-                else:
-                    await bot.process_commands(ctx)
+    if context.valid:
+        if isinstance(ctx.channel, discord.TextChannel):
+            if not ctx.channel.permissions_for(ctx.channel.guild.me).send_messages:
+                try:
+                    await ctx.author.send(f"*Houston, we have a problem!*\nYou tried to use `{ctx.content}` in {ctx.channel.mention}, but I don't have message permissions there.\nGive me perms and try again!")
+                except discord.Forbidden:
+                    pass # DMs disabled!
+            else:
+                await bot.process_commands(ctx)
 
   # All of the following commands are currently MANDATORY, these commands are part of the MAIN system other commands are added using a seperate file.
 


### PR DESCRIPTION
Full list of changes:

- Bans delete messages: The ban command now deletes messages less than 7 days old.

- Kick command: New kick command. What else do you want to know, duh?

- Softban command: New softban command. This command bans a user and immediately unbans it, meaning all messages less than 7 days old will get deleted. It's the same as a kick but it deletes messages less than 7 days old

- Changed some strings: The message after softbanning, banning and kicking now says the user moderated and has an :eyes: emoji

- Added a reason: Now bans, kicks and softbans have a reason. The reason is `moderator - reason`

- Default reason: If no reason was provided, kanelbulle will put as reason "No reason provided"

- Ban and softban now can ban users out of the server: They'll first try to get a member (inside the server), if no result then they'll try getting a user (outside of the server). If no result it'll just raise an error like it would by default

- Fixed error with `on_message` event: Apparently there was a typo with whitespaces

*Jeez that's a lot of changes*